### PR TITLE
Add a GitHub Actions workflow that runs Go linting on every push to main and on every pull request.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: ${{ matrix.module }}/go.sum
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9


### PR DESCRIPTION
Resolves #11 

- [x] Workflow runs on push (main only) and pull_request
- [x] Job is green on main branch
- [x] Clear output when linting fails
- [x] Linting is separate from the test workflow

I have set `only-new-issues` to reduce the "heavy/noisy" so only linting new/changed code from this point on but I have run golangci-lint locally and found only 1 issue