### PR TITLE
fix: restrict private key permissions after TLS key copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ cert:
 		-keyout gateway/envoy/tls/tls.key \
 		-out gateway/envoy/tls/tls.crt \
 		-subj "/CN=localhost"
-	@chmod 644 gateway/envoy/tls/tls.key gateway/envoy/tls/tls.crt
+	@chmod 644 gateway/envoy/tls/tls.crt
+	@chmod 600 gateway/envoy/tls/tls.key
 
 examples-index:
 	@./scripts/generate_examples_index.sh ./examples ./examples/index.json

--- a/deploy/certbot/copy-certs.sh
+++ b/deploy/certbot/copy-certs.sh
@@ -14,4 +14,5 @@ fi
 mkdir -p /etc/envoy/tls
 cp "${RENEWED_LINEAGE}/fullchain.pem" /etc/envoy/tls/tls.crt
 cp "${RENEWED_LINEAGE}/privkey.pem" /etc/envoy/tls/tls.key
-chmod 644 /etc/envoy/tls/tls.crt /etc/envoy/tls/tls.key
+chmod 644 /etc/envoy/tls/tls.crt
+chmod 600 /etc/envoy/tls/tls.key


### PR DESCRIPTION
Fixes #24

### Summary
After TLS private key files are copied, their permissions are now restricted with `chmod 600` to prevent unauthorized access.

### Changes
```
Makefile                     | 3 ++-
deploy/certbot/copy-certs.sh | 3 ++-
2 files changed, 4 insertions(+), 2 deletions(-)
```

Added `chmod 600` calls after each private key copy operation in both the Makefile and the certbot copy-certs script.

### Testing
- Verified the chmod commands target the correct key files
- Standard security practice for TLS private keys

---
<sub>If this fix isn't quite right, please leave feedback and I'll revise it.</sub>